### PR TITLE
Offset flag fix

### DIFF
--- a/src/coordio/utils.py
+++ b/src/coordio/utils.py
@@ -1176,7 +1176,8 @@ def object_offset(mags, mag_limits, lunation, waveName, obsSite, fmagloss=None,
     delta_dec = numpy.zeros(len(delta_ra))
 
     # zero out things with flag 32 in them but delta_ra > 0
-    delta_ra[(delta_ra > 0) & (offset_flag > 0)] = 0.
+    flag_32 = numpy.array([32 & int(fl) for fl in offset_flag], dtype=bool)
+    delta_ra[(delta_ra > 0) & flag_32] = 0.
     if check_valid_offset:
         if program is None:
             raise ValueError('Must provide program to check valid offsets!')

--- a/tests/test_offset.py
+++ b/tests/test_offset.py
@@ -65,7 +65,7 @@ def test_all_flags():
     offset_min_skybrightness = 1
     waveName = 'Boss'
     lunation = 'bright'
-    flags_test = [0, 1, 2, 8, 16, 32]
+    flags_test = [0, 1, 2, 8, 16, 32, 32]
     flags_test = [f if f == 0 else f + 64 for f in flags_test]
 
     test_mags = []
@@ -75,9 +75,11 @@ def test_all_flags():
     test_mags.append(numpy.array([m - 2 if m != -999. else m for m in mag_limits[lunation][waveName]]))
     test_mags.append(numpy.array([m - 2 if m != -999. else m for m in mag_limits[lunation][waveName]]))
     test_mags.append(numpy.array([5. if m != -999. else m for m in mag_limits[lunation][waveName]]))
+    test_mags.append(numpy.array([7. if m != -999. else m for m in mag_limits[lunation][waveName]]))
+    test_mags[-1][0] = 5.
 
-    skybrightness = [None, None, None, 0.3, None, None]
-    can_offset = [None, None, None, None, False, None]
+    skybrightness = [None, None, None, 0.3, None, None, None]
+    can_offset = [None, None, None, None, False, None, None]
     for flag, mag, sky, can_off in zip(flags_test, test_mags, skybrightness, can_offset):
         test_flags(flag, mag, mag_limits[lunation][waveName], lunation, waveName,
                    sky, offset_min_skybrightness, can_off)
@@ -86,7 +88,7 @@ def test_all_flags():
     offset_min_skybrightness = 1
     waveName = 'Boss'
     lunation = 'dark'
-    flags_test = [0, 1, 2, 8, 16, 32]
+    flags_test = [0, 1, 2, 8, 16, 32, 32]
     flags_test = [f if f == 0 else f + 64 for f in flags_test]
     
     test_mags = []
@@ -96,9 +98,11 @@ def test_all_flags():
     test_mags.append(numpy.array([m - 1 if m != -999. else m for m in mag_limits[lunation][waveName]]))
     test_mags.append(numpy.array([m - 1 if m != -999. else m for m in mag_limits[lunation][waveName]]))
     test_mags.append(numpy.array([12. if m != -999. else m for m in mag_limits[lunation][waveName]]))
+    test_mags.append(numpy.array([14. if m != -999. else m for m in mag_limits[lunation][waveName]]))
+    test_mags[-1][0] = 12.
 
-    skybrightness = [None, None, None, 0.3, None, None]
-    can_offset = [None, None, None, None, False, None]
+    skybrightness = [None, None, None, 0.3, None, None, None]
+    can_offset = [None, None, None, None, False, None, None]
     for flag, mag, sky, can_off in zip(flags_test, test_mags, skybrightness, can_offset):
         test_flags(flag, mag, mag_limits[lunation][waveName], lunation, waveName,
                    sky, offset_min_skybrightness, can_off)

--- a/tests/test_offset.py
+++ b/tests/test_offset.py
@@ -191,7 +191,7 @@ def test_all_flags():
     can_offset = [None]
     for flag, mag, sky, can_off in zip(flags_test, test_mags, skybrightness, can_offset):
         test_flags(flag, mag, numpy.zeros(10) - 999., lunation, waveName,
-                   sky, offset_min_skybrightness, can_off)
+                   sky, offset_min_skybrightness, can_off, True)
 
     # test get combination of all flags
     # Boss Bright
@@ -209,7 +209,7 @@ def test_all_flags():
     can_offset = [None]
     for flag, mag, sky, can_off in zip(flags_test, test_mags, skybrightness, can_offset):
         test_flags(flag, mag, mag_limits[lunation][waveName], lunation, waveName,
-                   sky, offset_min_skybrightness, can_off)
+                   sky, offset_min_skybrightness, can_off, False)
 
 
     # test bright neighbor exclusion radius for very bright stars

--- a/tests/test_offset.py
+++ b/tests/test_offset.py
@@ -66,17 +66,15 @@ def test_all_flags():
         with pytest.raises(ValueError, match='Must provide program to check valid offsets!'):
             delta_ra, delta_dec, offset_flag, valid_offset = object_offset(
                 numpy.vstack((mag, mag)), mag_limits, lunation,
-                waveName, 'APO', fmagloss=fmagloss,
-                skybrightness=sky,
+                waveName, 'APO', fmagloss=fmagloss, skybrightness=sky,
                 offset_min_skybrightness=offset_min_skybrightness,
-                can_offset=can_off,
+                can_offset=can_off_arr,
                 check_valid_offset=True)
         delta_ra, delta_dec, offset_flag, valid_offset = object_offset(
             numpy.vstack((mag, mag)), mag_limits, lunation,
-            waveName, 'APO', fmagloss=fmagloss,
-            skybrightness=sky,
+            waveName, 'APO', fmagloss=fmagloss, skybrightness=sky,
             offset_min_skybrightness=offset_min_skybrightness,
-            can_offset=can_off,
+            can_offset=can_off_arr,
             check_valid_offset=True,
             program=numpy.array(['science',
                                 'science']))


### PR DESCRIPTION
There was an issue in correctly accounting for all the flags when calculating the offset value. It does it on a per magnitude basis and then takes the maximum offset. The exception should be if there is a flag = 32 for one of the magnitudes (signals too bright for our offset limit), then the delta_ra returned should be 0 and the flag above reflect that it is invalid. This was not done properly previously. These changes fix this.

We do need to merged and tagged for the iota run. Everything looks good according to my tests. I am waiting for Mike to respond to make sure all of the changes work on his end.